### PR TITLE
Print vobsub errors

### DIFF
--- a/src/preprocessor.rs
+++ b/src/preprocessor.rs
@@ -20,7 +20,17 @@ pub type Result<T, E = vobsub::Error> = std::result::Result<T, E>;
 
 /// Return a vector of binarized subtitles.
 pub fn preprocess_subtitles(opt: &Opt) -> Result<Vec<PreprocessedVobSubtitle>> {
-    let idx = vobsub::Index::open(&opt.input)?;
+    let idx;
+    match vobsub::Index::open(&opt.input) {
+        Ok(i) => { idx = i; },
+        Err(e) => {
+            for msg in e.iter() {
+                println!("{}", msg);
+            };
+            panic!();
+        }
+    };
+
     let subtitles: Vec<vobsub::Subtitle> = idx
         .subtitles()
         .filter_map(|sub| match sub {


### PR DESCRIPTION
my .idx file didn't have a palette, and I didn't know why it was failing to open.
before, all errors from vobsub looked like this
```
An error occured: Could not parse VOB subtitles from subs.idx: Could not parse subs.idx
```
now there's some helpful errors, e.g.
```
Could not parse subs.idx
Could not find required key 'palette'
thread 'main' panicked at src/preprocessor.rs:30:13:
explicit panic
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
```
maybe a bit verbose but thats what I came up with.
  
unrelated rant:
after I added a palette, now there's another issue, `vobsub::Index::open` seems to return a completely empty vobsub::Subtitle (idk, I don't know rust) for my particular .idx file, which means vobsubocr just creates a blank .srt file. haven't figured that one out yet, I don't want to dig into the unmaintained vobsub crate so I tried VobSub2SRT instead and that worked. but I'm glad I tried vobsubocr, because VobSub2SRT does not complain about the blank palette, and assumes all colors are black, which produces an .srt full of blank entries. there's no way I would have figured that out.